### PR TITLE
Change QRCodes HTML to grid layout

### DIFF
--- a/anwesende/static/css/project.css
+++ b/anwesende/static/css/project.css
@@ -62,6 +62,7 @@ a:visited {
 
 .qrcode {
   width: 100mm;
+  max-width: 100%;
 }
 
 sup {

--- a/anwesende/templates/room/qrcodes.html
+++ b/anwesende/templates/room/qrcodes.html
@@ -20,7 +20,6 @@
   </p>
   <hr>
     {% for seat in seats %}
-    <div class="container">
       <div class="row align-items-center">
         <div class="col-sm-6 col-xs-12 col-md-7 col-lg-5">
           <img class="qrcode" src="{% url 'room:qrcode' seat.hash %}" aria-roledescription="QR Code">
@@ -49,9 +48,6 @@
           <span class="qrb-largeitem">{{seat.seatname}}</span>
         </div>
       </div>
-    </div>
-
-
     {% endfor %}
   </table>
 {% endblock content %}

--- a/anwesende/templates/room/qrcodes.html
+++ b/anwesende/templates/room/qrcodes.html
@@ -19,13 +19,13 @@
     {% endif %}
   </p>
   <hr>
-  <table> <!-- only a table makes Adobe PDF printer behave OK -->
     {% for seat in seats %}
-      <tr>
-        <td>
-          <img class="qrcode" src="{% url 'room:qrcode' seat.hash %}">
-        </td>
-        <td class="qrblock">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-sm-6 col-xs-12 col-md-7 col-lg-5">
+          <img class="qrcode" src="{% url 'room:qrcode' seat.hash %}" aria-roledescription="QR Code">
+        </div>
+        <div class="col-sm-6 col-xs-12 col-md-5 col-lg-5" aria-roledescription="QR Code Information">
           <span class="qrb-item">Please scan QR code and register your presence.</span>
           <br>
           <span class="qrb-item">{{ settings.SHORTURL_PREFIX }}{% url 'room:visit' seat.hash %}</span>
@@ -47,8 +47,11 @@
           <br>
           <span class="qrb-label"> </span>
           <span class="qrb-largeitem">{{seat.seatname}}</span>
-        </td>
-      </tr>
+        </div>
+      </div>
+    </div>
+
+
     {% endfor %}
   </table>
 {% endblock content %}


### PR DESCRIPTION
This PR changes qrcodes.html to a grid layout (instead of tables).
Printing in portrait or landscape mode should still result in the same layout as before (both in the same row).

The QRCode is still 100mm but will now be less than 100mm if it doesn't fit into the viewport (mobile screens).
Additional qrcode information is now under the qrcode on mobile screens.


@prechelt this might not be ideal as mobile users would now see the qr code above and the text code below, which is not the way it will be printed. However in it's current state someone previewing *and printing* from a mobile device wouldn't be aware of the text block on the right, so it could be worth the tradeoff.