### PR TITLE
Remove double hyphens in HTML comments

### DIFF
--- a/anwesende/templates/room/privacy.html
+++ b/anwesende/templates/room/privacy.html
@@ -1,7 +1,7 @@
 <h1>Information gemäß EU-Datenschutz-Grundverordnung (DSGVO) / 
   Information according to EU General Data Protection Regulation (GDPR)</h1>
 
-<!-------------------------------------------------------->
+<!-- -->
 <h2>Zweck und Datennutzung / Purpose and data use</h2>
 
 <p>
@@ -23,7 +23,7 @@
   Legal basis: {{ settings.LEGAL_BASIS_EN|safe }}.
 </p>
 
-<!-------------------------------------------------------->
+<!-- -->
 <h2>Verantwortlicher / Controller</h2>
 
 <p>
@@ -45,7 +45,7 @@
   you currently are.
 </p>
 
-<!-------------------------------------------------------->
+<!-- -->
 <h2>Welche Daten werden wie lange gespeichert? / Which data are stored for how long?</h2>
 
 <p>
@@ -85,7 +85,7 @@
   and then automatically deleted. 
 </p>
 
-<!-------------------------------------------------------->
+<!-- -->
 <h2>Sonstiges / Further detail</h2>
 
 <p>


### PR DESCRIPTION
According to the HTML5 standard:

> Following this sequence […] the text must not […] contain two consecutive U+002D HYPHEN-MINUS characters

https://dev.w3.org/html5/spec-LC/syntax.html#comments

So this PR removes the consecutive hyphens in privacy.html.